### PR TITLE
Supports to build maloader with clang and libc++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@ VERSION=0.4
 BITS=64
 
 GCC_EXTRA_FLAGS=-m$(BITS)
+ifeq ($(USE_LIBCXX), 1)
+GCCFLAGS=-g -Iinclude -Wall -MMD -fno-omit-frame-pointer -O $(GCC_EXTRA_FLAGS) -stdlib=libc++ -DUSE_LIBCXX
+LIBCXX_LD_EXTRA_FLAGS=-lc++ -lsupc++
+else
 GCCFLAGS=-g -Iinclude -Wall -MMD -fno-omit-frame-pointer -O $(GCC_EXTRA_FLAGS)
+endif
 CXXFLAGS=$(GCCFLAGS) -W -Werror
 CFLAGS=$(GCCFLAGS) -fPIC
 
@@ -73,17 +78,17 @@ $(MACTXTS): %.txt: %.bin
 #	touch $@
 
 extract: extract.o fat.o
-	$(CXX) $^ -o $@ -g -I. -W -Wall $(GCC_EXTRA_FLAGS)
+	$(CXX) $^ -o $@ -g -I. -W -Wall $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
 
 macho2elf: macho2elf.o mach-o.o fat.o log.o
-	$(CXX) $^ -o $@ -g $(GCC_EXTRA_FLAGS)
+	$(CXX) $^ -o $@ -g $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
 
 ld-mac: ld-mac.o mach-o.o fat.o log.o
-	$(CXX) $^ -o $@ -g -ldl -lpthread $(GCC_EXTRA_FLAGS)
+	$(CXX) $^ -o $@ -g -ldl -lpthread $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
 
 # TODO(hamaji): autotoolize?
 libmac.so: libmac/mac.o libmac/strmode.c
-	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS)
+	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
 
 dist:
 	cd /tmp && rm -fr maloader-$(VERSION) && git clone git@github.com:shinh/maloader.git && rm -fr maloader/.git && mv maloader maloader-$(VERSION) && tar -cvzf maloader-$(VERSION).tar.gz maloader-$(VERSION)

--- a/ld-mac.cc
+++ b/ld-mac.cc
@@ -49,8 +49,13 @@
 #include <map>
 #include <set>
 #include <string>
-#include <tr1/unordered_map>
 #include <vector>
+
+#ifdef USE_LIBCXX
+#include <unordered_map>
+#else
+#include <tr1/unordered_map>
+#endif
 
 #include "env_flags.h"
 #include "fat.h"
@@ -58,7 +63,9 @@
 #include "mach-o.h"
 
 using namespace std;
+#ifndef USE_LIBCXX
 using namespace std::tr1;
+#endif
 
 DEFINE_bool(TRACE_FUNCTIONS, false, "Show calling functions");
 DEFINE_bool(PRINT_TIME, false, "Print time spent in this loader");


### PR DESCRIPTION
Since XCode4.6 compilers seems built with clang and libc++, we will see a lot of error messages that there are undefined symbols when we use maloader built with g++. To make XCode4.6 compiler, one solution is to use use maloader compiled with clang and libc++.

This patch supports to build maloader with clang and libc++.

When compiling with clang and libc++, you have to set CC and CXX, and define USE_LIBCXX=1 like the following:
CC=/path/to/clang CXX=/path/to/clang++ USE_LIBCXX=1 make

I have checked this patch works only with LLVM3.2 and Ubuntu precise.
