### PR TITLE
Reduce link warning and make CXX_LDFLAGS more flexible to add user options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GCC_EXTRA_FLAGS=-m$(BITS)
 GCCFLAGS=-g -Iinclude -Wall -MMD -fno-omit-frame-pointer -O $(GCC_EXTRA_FLAGS)
 ifeq ($(USE_LIBCXX), 1)
 GCCFLAGS+=-stdlib=libc++ -DUSE_LIBCXX
-LIBCXX_LD_EXTRA_FLAGS=-lc++ -lsupc++
+CXX_LDFLAGS+=-lc++ -lsupc++
 endif
 CXXFLAGS=$(GCCFLAGS) -W -Werror
 CFLAGS=$(GCCFLAGS) -fPIC
@@ -77,17 +77,17 @@ $(MACTXTS): %.txt: %.bin
 #	touch $@
 
 extract: extract.o fat.o
-	$(CXX) $^ -o $@ -g -I. -W -Wall $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
+	$(CXX) $^ -o $@ -g -I. -W -Wall $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
 
 macho2elf: macho2elf.o mach-o.o fat.o log.o
-	$(CXX) $^ -o $@ -g $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
+	$(CXX) $^ -o $@ -g $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
 
 ld-mac: ld-mac.o mach-o.o fat.o log.o
-	$(CXX) $^ -o $@ -g -ldl -lpthread $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
+	$(CXX) -v $^ -o $@ -g -ldl -lpthread $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
 
 # TODO(hamaji): autotoolize?
 libmac.so: libmac/mac.o libmac/strmode.c
-	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS) $(LIBCXX_LD_EXTRA_FLAGS)
+	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS) $(LDFLAGS)
 
 dist:
 	cd /tmp && rm -fr maloader-$(VERSION) && git clone git@github.com:shinh/maloader.git && rm -fr maloader/.git && mv maloader maloader-$(VERSION) && tar -cvzf maloader-$(VERSION).tar.gz maloader-$(VERSION)


### PR DESCRIPTION
Since -lc++ and -lsupc++ are not necessary for $(CC),
we would like to define CXX_LDFLAGS, and use it only for $(CXX).
