### PR TITLE
Fix resolving libncurses.5.4.dylib

### DIFF
--- a/ld-mac.cc
+++ b/ld-mac.cc
@@ -272,13 +272,15 @@ class MachOLoader {
  public:
   MachOLoader()
     : last_addr_(0) {
-    dylib_to_so_.insert(make_pair(
-                          "/System/Library/Frameworks/CoreFoundation.framework"
-                          "/Versions/A/CoreFoundation",
-                          "libCoreFoundation.so"));
-    dylib_to_so_.insert(make_pair(
-                          "/usr/lib/libncurses.5.4.dylib",
-                          "libncurses.so"));
+    dylib_to_so_["/System/Library/Frameworks/CoreFoundation.framework"
+                 "/Versions/A/CoreFoundation"].push_back(
+                     "libCoreFoundation.so");
+
+    // From Xcode 5.1, clang requires libncurses. However, since libncurses.so
+    // looks a linker script (at least ubuntu 12.04), we cannot dlopen it.
+    // We need to load libtinfo.so and libncurses.so.5 both.
+    dylib_to_so_["/usr/lib/libncurses.5.4.dylib"].push_back("libtinfo.so");
+    dylib_to_so_["/usr/lib/libncurses.5.4.dylib"].push_back("libncurses.so.5");
 
     symbol_to_so_.insert(make_pair("uuid_clear", "libuuid.so"));
     symbol_to_so_.insert(make_pair("uuid_compare", "libuuid.so"));
@@ -477,12 +479,15 @@ class MachOLoader {
       if (!loaded_dylibs_.insert(dylib).second)
         continue;
 
-      const string so = dylib_to_so_[dylib];
-      if (!so.empty()) {
-        LOG << "Loading " << so << " for " << dylib << endl;
-        if (!dlopen(so.c_str(), RTLD_LAZY | RTLD_GLOBAL)) {
-          fprintf(stderr, "Couldn't load %s for %s: %s\n",
-                  so.c_str(), dylib.c_str(), dlerror());
+      if (dylib_to_so_.count(dylib)) {
+        const vector<string>& sos = dylib_to_so_[dylib];
+        for (size_t i = 0; i < sos.size(); ++i) {
+          const string& so = sos[i];
+          LOG << "Loading " << so << " for " << dylib << endl;
+          if (!dlopen(so.c_str(), RTLD_LAZY | RTLD_GLOBAL)) {
+            fprintf(stderr, "Couldn't load %s for %s: %s\n",
+                    so.c_str(), dylib.c_str(), dlerror());
+          }
         }
       }
 
@@ -780,7 +785,7 @@ class MachOLoader {
   vector<uint64_t> init_funcs_;
   Exports exports_;
   vector<pair<string, char*> > seen_weak_binds_;
-  map<string, string> dylib_to_so_;
+  map<string, vector<string> > dylib_to_so_;
   map<string, string> symbol_to_so_;
   set<string> loaded_dylibs_;
 };


### PR DESCRIPTION
clang on Xcode 5.1 requires libncurses.

When resolving libcurses.5.4.dylib, actually we need to load libtinfo.so
and libncurses.so.5. Since libncurses.so is a linker script, we cannot
do dlopen for it.

This was not a problem before Xcode 5.1, since clang for those does not
require libncurses.
