### PR TITLE
Add gethostuuid for Xcode 7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ld-mac: ld-mac.o mach-o.o fat.o log.o
 
 # TODO(hamaji): autotoolize?
 libmac.so: libmac/mac.o libmac/strmode.c
-	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS) $(LDFLAGS)
+	$(CC) -shared $^ $(CFLAGS) -o $@ $(GCC_EXTRA_FLAGS) $(LDFLAGS) -luuid
 
 dist:
 	cd /tmp && rm -fr maloader-$(VERSION) && git clone git@github.com:shinh/maloader.git && rm -fr maloader/.git && mv maloader maloader-$(VERSION) && tar -cvzf maloader-$(VERSION).tar.gz maloader-$(VERSION)

--- a/libmac/mac.c
+++ b/libmac/mac.c
@@ -50,6 +50,7 @@
 
 #include <mac-ctype.h>
 #include <runetype.h>
+#include <uuid/uuid.h>
 
 #ifdef NOLOG
 # define LOGF(...) if (0) fprintf(stderr, __VA_ARGS__)
@@ -68,6 +69,8 @@ typedef int __darwin_ct_rune_t;     /* ct_rune_t */
 #include "popcountdi2.c"
 #include "runetable.c"
 #include "stack_protector-obsd.c"
+
+#define UNUSED_PARAMETER(x) (void)(x)
 
 struct __darwin_timespec {
   time_t tv_sec;
@@ -1381,6 +1384,18 @@ void __darwin_qsort_r(void* base, size_t nel, size_t width, void* thunk,
   ctx.compar = compar;
   ctx.thunk = thunk;
   qsort_r(base, nel, width, &__darwin_qsort_r_helper, &ctx);
+}
+
+// uuid_t is unsigned char[16] both on Linux and Mac.
+int __darwin_gethostuuid(uuid_t id, const struct timespec *wait)
+{
+  UNUSED_PARAMETER(wait);
+
+  // TODO(mayah): Returns the same uuid for now.
+  // It might be better if we can generate uuid per host
+  // from mac adderss or something?
+  uuid_parse("550e8400-e29b-41d4-a716-446655440000", id);
+  return 0;
 }
 
 unsigned int arc4random() {

--- a/rename.tab
+++ b/rename.tab
@@ -165,3 +165,5 @@ WRAP(qsort_r)
 WRAP(newlocale)
 
 WRAP(compat_mode)
+
+WRAP(gethostuuid)


### PR DESCRIPTION
Compiler on Xcode 7.0 calls gethostuuid and uuid_unparse.
gethostuuid is mac syscall, so we need to implement it in libmac.
uuid_unparse can be provided by uuid library.