### PR TITLE
Port to FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ VERSION=0.4
 BITS=64
 
 GCC_EXTRA_FLAGS=-m$(BITS)
-GCCFLAGS+=-g -Iinclude -Wall -MMD -fno-omit-frame-pointer -O $(GCC_EXTRA_FLAGS)
+GCCFLAGS+=-g -Iinclude -Wall -MMD -fno-omit-frame-pointer -O1 $(GCC_EXTRA_FLAGS)
 ifeq ($(USE_LIBCXX), 1)
 GCCFLAGS+=-stdlib=libc++ -DUSE_LIBCXX
 CXX_LDFLAGS+=-lc++ -lsupc++
 CC=clang
 CXX=clang++
 endif
-CXXFLAGS=$(GCCFLAGS) -W -Werror --std=c++11
+CXXFLAGS=$(GCCFLAGS) -Wextra -Werror --std=c++11
 CFLAGS=$(GCCFLAGS) -fPIC
 
 EXES=libmac.so extract macho2elf ld-mac
@@ -30,6 +30,7 @@ MAC_CC=PATH=$(MAC_BIN_DIR) ./ld-mac $(MAC_BIN_DIR)/gcc --sysroot=$(MAC_TOOL_DIR)
 MAC_CXX=PATH=$(MAC_BIN_DIR) ./ld-mac $(MAC_BIN_DIR)/g++ --sysroot=$(MAC_TOOL_DIR)
 MAC_OTOOL=./ld-mac $(MAC_BIN_DIR)/otool
 MAC_TARGETS=ld-mac $(MACBINS) $(MACTXTS)
+DL_LIBS=-ldl
 else
 MAC_CC=$(CC)
 MAC_CXX=$(CXX)
@@ -79,13 +80,13 @@ $(MACTXTS): %.txt: %.bin
 #	touch $@
 
 extract: extract.o fat.o
-	$(CXX) $^ -o $@ -g -I. -W -Wall $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
+	$(CXX) $^ -o $@ -g -I. -Wall $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
 
 macho2elf: macho2elf.o mach-o.o fat.o log.o
 	$(CXX) $^ -o $@ -g $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
 
 ld-mac: ld-mac.o mach-o.o fat.o log.o
-	$(CXX) -v $^ -o $@ -g -ldl -lpthread $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS)
+	$(CXX) -v $^ -g $(GCC_EXTRA_FLAGS) $(CXX_LDFLAGS) -o $@ $(DL_LIBS) -lpthread $(LIBS)
 
 # TODO(hamaji): autotoolize?
 libmac.so: libmac/mac.o libmac/strmode.c

--- a/include/_types.h
+++ b/include/_types.h
@@ -28,13 +28,21 @@
 //#include <sys/_types.h>
 
 #if __GNUC__ > 2 || __GNUC__ == 2 && __GNUC_MINOR__ >= 7
+#ifndef __strfmonlike
 #define __strfmonlike(fmtarg, firstvararg) \
 		__attribute__((__format__ (__strfmon__, fmtarg, firstvararg)))
+#endif
+#ifndef __strftimelike
 #define __strftimelike(fmtarg) \
 		__attribute__((__format__ (__strftime__, fmtarg, 0)))
+#endif
 #else
+#ifndef __strfmonlike
 #define __strfmonlike(fmtarg, firstvararg)
+#endif
+#ifndef __strftimelike
 #define __strftimelike(fmtarg)
+#endif
 #endif
 
 typedef	int		__darwin_nl_item;

--- a/include/mac-runetype.h
+++ b/include/mac-runetype.h
@@ -36,8 +36,8 @@
  *	@(#)runetype.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef	_RUNETYPE_H_
-#define	_RUNETYPE_H_
+#ifndef	_MAC_RUNETYPE_H_
+#define	_MAC_RUNETYPE_H_
 
 #include <_types.h>
 #include <wchar.h>
@@ -45,7 +45,7 @@
 typedef wchar_t __darwin_rune_t;
 typedef size_t __darwin_size_t;
 
-#if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
+#if 0 && (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE))
 
 #ifndef	_SIZE_T
 #define _SIZE_T
@@ -87,12 +87,12 @@ typedef struct {
 	__darwin_rune_t	__max;		/* Last rune (inclusive) of the range */
 	__darwin_rune_t	__map;		/* What first maps to in maps */
 	uint32_t	*__types;	/* Array of types in range */
-} _RuneEntry;
+} _MacRuneEntry;
 
 typedef struct {
 	int		__nranges;	/* Number of ranges stored */
-	_RuneEntry	*__ranges;	/* Pointer to the ranges */
-} _RuneRange;
+	_MacRuneEntry	*__ranges;	/* Pointer to the ranges */
+} _MacRuneRange;
 
 typedef struct {
 	char		__name[14];	/* CHARCLASS_NAME_MAX = 14 */
@@ -116,9 +116,9 @@ typedef struct {
 	 * Their data is actually contiguous with this structure so as to make
 	 * it easier to read/write from/to disk.
 	 */
-	_RuneRange	__runetype_ext;
-	_RuneRange	__maplower_ext;
-	_RuneRange	__mapupper_ext;
+	_MacRuneRange	__runetype_ext;
+	_MacRuneRange	__maplower_ext;
+	_MacRuneRange	__mapupper_ext;
 
 	void		*__variable;	/* Data which depends on the encoding */
 	int		__variable_len;	/* how long that data is */
@@ -128,13 +128,13 @@ typedef struct {
 	 */
 	int		__ncharclasses;
 	_RuneCharClass	*__charclasses;
-} _RuneLocale;
+} _MacRuneLocale;
 
 #define	_RUNE_MAGIC_A	"RuneMagA"	/* Indicates version A of RuneLocale */
 
 __BEGIN_DECLS
-extern _RuneLocale _DefaultRuneLocale;
-extern _RuneLocale *_CurrentRuneLocale;
+extern _MacRuneLocale _MacDefaultRuneLocale;
+extern _MacRuneLocale *_MacCurrentRuneLocale;
 __END_DECLS
 
-#endif	/* !_RUNETYPE_H_ */
+#endif	/* !_MAC_RUNETYPE_H_ */

--- a/ld-mac.cc
+++ b/ld-mac.cc
@@ -841,7 +841,7 @@ void MachOLoader::boot(
                    " push %%eax;\n"
                    " jmp *%0;\n"
                    // TODO(hamaji): Fix parameters
-                   ::"r"(entry), "r"(argc), "r"(argv + argc), "g"(envp)
+                   ::"r"((uint32_t)entry), "r"(argc), "r"(argv + argc), "g"(envp)
                    :"%eax", "%edx");
 #endif
 }

--- a/libmac/runetable.c
+++ b/libmac/runetable.c
@@ -55,7 +55,7 @@
  * SUCH DAMAGE.
  */
 
-_RuneLocale _DefaultRuneLocale = {
+_MacRuneLocale _MacDefaultRuneLocale = {
     _RUNE_MAGIC_A,
     "none",
     _none_sgetrune,

--- a/macho2elf.cc
+++ b/macho2elf.cc
@@ -43,6 +43,10 @@
 
 #include "mach-o.h"
 
+#ifndef R_X86_64_JUMP_SLOT
+#define R_X86_64_JUMP_SLOT 7
+#endif
+
 using namespace std;
 
 static map<string, string> g_rename;
@@ -323,7 +327,7 @@ class ELFBuilder {
           name = found->second.c_str();
         }
 
-        int sym_index = putELFSym(symtab, bind->vmaddr, 0,
+        uint64_t sym_index = putELFSym(symtab, bind->vmaddr, 0,
                                   ELF64_ST_INFO(STB_GLOBAL, STT_FUNC),
                                   0, 0, name);
 


### PR DESCRIPTION
Tested with FreeBSD 10 and 11.

Includes pull request #25 for correct building for FreeBSD i386.

Major changes/fixes:
* FreeBSD have their own `runetype.h`, renamed Darwin-specific `runetype.h` to `mac-runetype.h` just like `mac-ctype.h`, alone with associated identifiers, to avoid conflicts.
* Neither FreeBSD kernel nor C library provide `*stat64`, `*statfs64` and `fseeko64`, avoid using them in such case.
* Implements getting executable file path using **sysctl(3)**, in addition to the Linux-specific `/proc/self/exe`.
* Handles some differences in pthread-related macros between GNU and FreeBSD.
* **qsort_r(3)** has different prototype between GNU and FreeBSD, handled it accordingly.
* Function `MachOLoader::loadSegments(const MachO &, intptr *, intptr *)` contains a bug where it calls **mmap(2)** with `MAP_ANON` but `0` as `fd`, this is invalid, as kindly pointed out by FreeBSD kernel by a `EINVAL`.
